### PR TITLE
Clustering is feature toggleable

### DIFF
--- a/src/eyeos-rabbitmq-auth-backend-http.js
+++ b/src/eyeos-rabbitmq-auth-backend-http.js
@@ -37,17 +37,28 @@ var logger = log2out.getLogger('rabbitmq-auth-backend-http');
 
 logger.info('Current settings are:\n', settings);
 
-if (cluster.isMaster) {
-    // Fork workers.
-    for (var i = 0; i < numCPUs; i++) {
-        cluster.fork();
-    }
+var rabbitmqAuhBackendHttp, notifier;
 
-    cluster.on('exit', function(worker, code, signal) {
-        console.log('worker ' + worker.process.pid + ' died');
-    });
-} else {
-    var rabbitmqAuhBackendHttp = new Server();
+if (settings.useCluster) {
+    if (cluster.isMaster) {
+        // Fork workers.
+        for (var i = 0; i < numCPUs; i++) {
+            cluster.fork();
+        }
+
+        cluster.on('exit', function (worker, code, signal) {
+            console.log('worker ' + worker.process.pid + ' died');
+        });
+    } else {
+        startApplication();
+    }
+}
+else {
+    startApplication();
+}
+
+function startApplication () {
+    rabbitmqAuhBackendHttp = new Server();
 
     logger.info(">>>> Starting rabbitmqAuhBackendHttp in %s:%d",
         settings.bindAddress,

--- a/src/eyeos-rabbitmq-auth-backend-http.js
+++ b/src/eyeos-rabbitmq-auth-backend-http.js
@@ -37,8 +37,6 @@ var logger = log2out.getLogger('rabbitmq-auth-backend-http');
 
 logger.info('Current settings are:\n', settings);
 
-var rabbitmqAuhBackendHttp, notifier;
-
 if (settings.useCluster) {
     if (cluster.isMaster) {
         // Fork workers.
@@ -58,15 +56,17 @@ else {
 }
 
 function startApplication () {
-    rabbitmqAuhBackendHttp = new Server();
+    var rabbitmqAuthBackendHttp, notifier;
 
-    logger.info(">>>> Starting rabbitmqAuhBackendHttp in %s:%d",
+    rabbitmqAuthBackendHttp = new Server();
+
+    logger.info(">>>> Starting rabbitmqAuthBackendHttp in %s:%d",
         settings.bindAddress,
         settings.port
     );
 
-    rabbitmqAuhBackendHttp.start(settings.bindAddress, settings.port);
+    rabbitmqAuthBackendHttp.start(settings.bindAddress, settings.port);
 
-    var notifier = new Notifier();
+    notifier = new Notifier();
     notifier.registerService();
 }

--- a/src/settings.js
+++ b/src/settings.js
@@ -46,8 +46,8 @@ var settings = {
             db: process.env.EYEOS_RABBITMQ_AUTH_BACKEND_HTTP_MONGODB || "eyeos",
             collection: process.env.EYEOS_RABBITMQ_AUTH_BACKEND_HTTP_MONGOCOLLECTION || "vmuserservice"
         }
-    }
-   
+    },
+    useCluster: process.env.EYEOS_RABBITMQ_AUTH_BACKEND_HTTP_USE_CLUSTER === "true" || false
 };
 
 module.exports = settings;


### PR DESCRIPTION
Now that open365 targets multiple platforms, we need the flexibility to
perform optimally for each unique environment.  This could mean getting
more out of the CPU by launching multi-node processes in a large
environment with a lot of processing power or reducing to a single-
threaded process for smaller environments with minimal processing power.

For example, clustering should be enabled for production, but perhaps
disabled for users installing open365 in a raspberry pi.

Clustering can now be enabled/disabled with the envar
EYEOS_RABBITMQ_AUTH_BACKEND_HTTP_USE_CLUSTER
